### PR TITLE
[Hotfix] Fix pykd.getVaProtection Error in kernel debug mode (temporary)

### DIFF
--- a/TWindbg/utils.py
+++ b/TWindbg/utils.py
@@ -72,6 +72,7 @@ def disasm(addr):
     return op_str, asm_str
 
 def is_executable(addr):
+    if pykd.isKernelDebugging(): return False # we need to find a way to get the memory protection information in kernel debug mode
     if "Execute" in str(pykd.getVaProtect(addr)):
         return True
     else:


### PR DESCRIPTION
Currently in pykd there's no API for getting memory protection info in kernel debug mode. For now we just have to assume that there's no execution memory page in kernel mode and smart-dereference the pointer with `data` type.  If we want to disasm the code, use the original Windbg command ( the `u` command )