### PR TITLE
fix: RBP parse error when booting

### DIFF
--- a/TWindbg/context.py
+++ b/TWindbg/context.py
@@ -189,11 +189,14 @@ class ContextHandler(pykd.eventHandler):
         for ptr in ptr_values[:-2:]:
             ptrs_str += "{:#x} --> ".format(ptr)
         # handle last two's format
-        last_ptr, last_val = ptr_values[-2], ptr_values[-1]
-        if is_cyclic:
-            ptrs_str += "{:#x} --> {:#x}".format(last_ptr, last_val) + color.dark_red(" ( cyclic dereference )")
+        if len(ptr_values) > 1:
+            last_ptr, last_val = ptr_values[-2], ptr_values[-1]
+            if is_cyclic:
+                ptrs_str += "{:#x} --> {:#x}".format(last_ptr, last_val) + color.dark_red(" ( cyclic dereference )")
+            else:
+                ptrs_str += self.enhance_type(last_ptr, last_val)
         else:
-            ptrs_str += self.enhance_type(last_ptr, last_val)
+            ptrs_str += "{:#x}".format(ptr_values[0])
         pykd.dprintln(ptrs_str, dml=True)
 
     def enhance_type(self, ptr, val):

--- a/TWindbg/context.py
+++ b/TWindbg/context.py
@@ -219,8 +219,9 @@ class ContextHandler(pykd.eventHandler):
             val = deref_ptr(ptr)
             if val == None: # no more dereference
                 break
-            elif val in ptr_values[:-1:]: # cyclic dereference
-                ptr_values.append(val)
+            elif val in ptr_values: # cyclic dereference
+                if val != ptr_values[-1]:
+                    ptr_values.append(val)
                 is_cyclic = True
                 break
             else:


### PR DESCRIPTION
## Environment
* Host: Windows 10 21H1
* VM: Windows 10 1709
* WinDbg Version: 10.0.22621.382
* TWindbg Commit: 3d595910420ef4d33e46f1ab33224855c74f182e

## Reproduce
I break into WinDbg when booting the VM, but it fails to parse the reference of RBP.
![image](https://user-images.githubusercontent.com/33378686/190913356-0bb4d613-05b1-40c0-a98d-4c414392ad4f.png)

The root cause seems to be the value of RBP is `0xffffffff`, then the function `deref_ptr` return `None`.

Below is the screenshot after fixing.
![image](https://user-images.githubusercontent.com/33378686/190913584-f84548ff-6135-418f-86e5-f750e0542856.png)